### PR TITLE
Fixed readme.md filename

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
   <project remote="oe" revision="eb4563b83be0a57ede4269ab19688af6baa62cd2" name="meta-openembedded" path="sources/meta-openembedded"/>
 
   <project remote="3dr" revision="master" name="3dr-yocto-bsp-base" path="sources/base">
-	<copyfile dest="README" src="README"/>
+	<copyfile dest="README.md" src="README.md"/>
 	<copyfile dest="setup-environment" src="setup-environment"/>
   </project>
 


### PR DESCRIPTION
The filename is README.md but the XML was looking for README.  This was causing errors in the build setup. 